### PR TITLE
Fix plugin load of fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
     && git clone --depth 1 -b v${COREDNS_VERSION} https://github.com/coredns/coredns \
     && cp -rf plugins/* coredns/plugin/ \
     && cd coredns \
-    && sed -i "/^forward:.*/a fallback:fallback" plugin.cfg \
+    && sed -i "/^forward:.*/i fallback:fallback" plugin.cfg \
     && sed -i "/^hosts:.*/a mdns:mdns" plugin.cfg \
     && sed -i "/route53:route53/d" plugin.cfg \
     && sed -i "/clouddns:clouddns/d" plugin.cfg \


### PR DESCRIPTION
The current fallback is not working right because of the load order.
That means it will not fix DNS issues magic which user have on here network.

Fix: https://github.com/home-assistant/supervisor/issues/2955