### PR TITLE
Prevent intermittent DNS failures when DNS server in local network is used.

### DIFF
--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -12,7 +12,7 @@
         rcode NOERROR
     }
     mdns
-    forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} dns://127.0.0.1:5553 {
+    forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }}{{ if and (len .servers | eq 0) (len .locals | eq 0) }} dns://127.0.0.1:5553{{ end }} {
         except local.hass.io
         policy sequential
         health_check 1m


### PR DESCRIPTION
Since the default forward policy is configured for sequential load balancing do not use dns://127.0.0.1:5553 when a DNS server is specified either through DHCP ('.locals') or the local configuration ('.servers') since this will result in intermittent DNS lookup errors for hosts in the local network that are only known through the specified DNS servers.

To expand a bit, when a DNS server is specified either through DHCP ('.locals') or the local configuration ('.servers') the forward line will become something like: forward . 'dns://192.168.0.1 dns://127.0.0.1:5553'.
This means that DNS lookups for hosts in the local network (192.168.0.0/24) will, depending on the circumstances, be forwarded either 192.168.0.1 or 127.0.0.1:5553. When the DNS lookup for a host in the local network is forwarded to 127.0.0.1:5553, the lookup will fail.

edit: I had .locals and .servers the wrong way around, this is now fixed in the text above.