### PR TITLE
Remove hardcoded DNS servers

### DIFF
--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -11,21 +11,10 @@
         rcode NOERROR
     }
     mdns
-    forward . dns://172.0.0.11:53 dns://127.0.0.1:5553 {
+    forward . dns://127.0.0.11:53 {
         except local.hass.io
         policy sequential
         health_check 1m
     }
-    cache
-}
-
-.:5553 {
-    log
-    errors
-    forward . tls://1.1.1.1 tls://1.0.0.1 {
-        tls_servername cloudflare-dns.com
-        except local.hass.io
-        health_check 5m
-    }
-    cache
+    cache 600
 }

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -12,25 +12,10 @@
         rcode NOERROR
     }
     mdns
-    forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} dns://127.0.0.1:5553 {
+    forward . {{ if .servers }}{{ join " " .servers }}{{ else if .locals }}{{ join " " .locals }}{{ else }}dns://127.0.0.11:53{{ end }} {
         except local.hass.io
         policy sequential
         health_check 1m
-    }
-    fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553
-    cache 600
-}
-
-.:5553 {
-    log {{ if not .debug }}{
-        class error
-    }{{ end }}
-    errors
-    {{ if .debug }}debug{{ end }}
-    forward . tls://1.1.1.1 tls://1.0.0.1 {
-        tls_servername cloudflare-dns.com
-        except local.hass.io
-        health_check 5m
     }
     cache 600
 }


### PR DESCRIPTION
If DNS servers have been manually configured, use the manually configured DNS servers only. Otherwise if DNS servers have been supplied by DHCP, use the DNS servers supplied by DHCP only. Otherwise use Docker Embedded DNS server.

https://github.com/home-assistant/plugin-dns/issues/20