### PR TITLE
Use UDP instead of TLS for failover DNS servers

### DIFF
--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -22,8 +22,7 @@
 .:5553 {
     log
     errors
-    forward . tls://1.1.1.1 tls://1.0.0.1 {
-        tls_servername cloudflare-dns.com
+    forward . dns://1.1.1.1 dns://1.0.0.1 {
         except local.hass.io
         health_check 5m
     }

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -27,8 +27,7 @@
     }{{ end }}
     errors
     {{ if .debug }}debug{{ end }}
-    forward . tls://1.1.1.1 tls://1.0.0.1 {
-        tls_servername cloudflare-dns.com
+    forward . dns://1.1.1.1 dns://1.0.0.1 {
         except local.hass.io
         health_check 5m
     }


### PR DESCRIPTION
This will allow the requests to be redirected and will reduce the performance impact caused by Home Assistant losing connectivity to Cloudflare's DNS servers due to internet loss, blocking, etc.