### PR TITLE
Fix local DNS resolution issue

### DIFF
--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -11,11 +11,12 @@
         rcode NOERROR
     }
     mdns
-    forward . dns://172.0.0.11:53 dns://127.0.0.1:5553 {
+    forward . dns://127.0.0.11:53 {
         except local.hass.io
         policy sequential
         health_check 1m
     }
+    fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553
     cache
 }
 

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -12,7 +12,7 @@
         rcode NOERROR
     }
     mdns
-    forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} dns://127.0.0.1:5553 {
+    forward . {{ if .servers }}{{ join " " .servers }}{{ else if .locals }}{{ join " " .locals }}{{ else }}dns://127.0.0.11:53{{ end }} {
         except local.hass.io
         policy sequential
         health_check 1m


### PR DESCRIPTION
1. Always try local DNS before Cloudflare
2. If DNS servers are configured manually and via DHCP, only use manually configured DNS servers not both

Note, this does not remove Cloudflare DNS server fallback.