### PR TITLE
Return noerror if any answers found (A or AAAA)

### DIFF
--- a/plugins/mdns/mdns_test.go
+++ b/plugins/mdns/mdns_test.go
@@ -91,6 +91,8 @@ func TestAddARecord(t *testing.T) {
 			"myservice.local	60	IN	A	192.168.1.1",
 			"myservice.local	60	IN	A	10.1.1.1",
 		}, true},
+		{"success on AAAA if only A found", "mymachine.local", dns.TypeAAAA, nilResponseWriter{}, 1, ipv4, []string{}, true},
+		{"success on A if only AAAA found", "mymachine.local", dns.TypeA, nilResponseWriter{}, 1, ipv6, []string{}, true},
 	}
 	for _, tc := range testCases {
 		m := MDNS{nil, nil, tc.ifc}

--- a/plugins/mdns/setup.go
+++ b/plugins/mdns/setup.go
@@ -21,12 +21,12 @@ func setup(c *caddy.Controller) error {
 	var m MDNS
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
-		log.Error("could not connect to systemd resolver due to %s", err)
+		log.Error("could not connect to systemd resolver due to: ", err)
 		log.Error("mdns and llmnr urls will not resolve in without this")
 
 		m = MDNS{
 			Resolver: nil,
-			Ifc: 0,
+			Ifc:      0,
 		}
 	} else {
 		bus_object := conn.Object("org.freedesktop.resolve1", "/org/freedesktop/resolve1")


### PR DESCRIPTION
Must always return a `NOERROR` response if we found any `A` or `AAAA` responses, even if we didn't find any which answered their question (i.e. `A` answers only for an `AAAA` query). Returning an `NXDOMAIN` for `AAAA` but not `A` (or vice versa) breaks musl.