### PR TITLE
Cloudflare as fallback only and no healthcheck

### DIFF
--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -14,7 +14,9 @@
     mdns
     forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} {
         except local.hass.io
+        policy sequential
         health_check 1m
+        max_fails 5
     }
     fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553
     cache 600
@@ -28,6 +30,7 @@
     {{ if .debug }}debug{{ end }}
     forward . tls://1.1.1.1 tls://1.0.0.1 {
         tls_servername cloudflare-dns.com
+        max_fails 0
         except local.hass.io
     }
     cache 600

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -12,7 +12,7 @@
         rcode NOERROR
     }
     mdns
-    forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} dns://127.0.0.1:5553 {
+    forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} {
         except local.hass.io
         policy sequential
         health_check 1m
@@ -30,7 +30,6 @@
     forward . tls://1.1.1.1 tls://1.0.0.1 {
         tls_servername cloudflare-dns.com
         except local.hass.io
-        health_check 5m
     }
     cache 600
 }

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -14,7 +14,6 @@
     mdns
     forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} {
         except local.hass.io
-        policy sequential
         health_check 1m
     }
     fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553


### PR DESCRIPTION
Cloudflare's DNS server in the corefile config was intended only to be a fallback, one to be used when the provided ones failed. However it is currently listed twice in this config: as a fallback and as the last forwarding DNS server. This creates two issues:

1. We healthcheck cloudflare's DNS server every minute. This is excessive and unnecessary. Cloudflare's DNS server isn't likely to go down, what's more likely is the user has it blocked which then leads to runaway healthchecking (#64). Plus we have no other fallback anyway so whether its down or not won't change our DNS decisioning here.
2. Coredns seems to get "stuck" on the fallback. I don't have a great explanation for this but I do have a lot of issues to point to (#51, #54, #20).Perhaps its because it starts skipping servers after [fails > maxfails](https://github.com/coredns/coredns/blob/master/plugin/forward/proxy.go#L59) and Cloudflare is always the last one standing from this? Way less likely to fail then a local DNS server.

We made the fallback plugin so we could use cloudflare as a fallback if the others fail to minimize the amount of DNS issues faced by users that pay no attention to DNS and expect it to just work. We should limit our usage of it to just that so the local DNS servers are always preferred.