### PR TITLE
No SERVFAIL and no forwarding multicast names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     && cp -rf plugins/* coredns/plugin/ \
     && cd coredns \
     && sed -i "/^template:template/d" plugin.cfg \
-    && sed -i "/^hosts:.*/i template:template" plugin.cfg \
+    && sed -i "/^hosts:.*/a template:template" plugin.cfg \
     && sed -i "/^forward:.*/i fallback:fallback" plugin.cfg \
     && sed -i "/^hosts:.*/a mdns:mdns" plugin.cfg \
     && sed -i "/route53:route53/d" plugin.cfg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN \
     && git clone --depth 1 -b v${COREDNS_VERSION} https://github.com/coredns/coredns \
     && cp -rf plugins/* coredns/plugin/ \
     && cd coredns \
+    && sed -i "/^template:template/d" plugin.cfg \
+    && sed -i "/^hosts:.*/i template:template" plugin.cfg \
     && sed -i "/^forward:.*/i fallback:fallback" plugin.cfg \
     && sed -i "/^hosts:.*/a mdns:mdns" plugin.cfg \
     && sed -i "/route53:route53/d" plugin.cfg \

--- a/plugins/mdns/mdns.go
+++ b/plugins/mdns/mdns.go
@@ -100,16 +100,16 @@ func (m MDNS) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		// There may be uncommon errors though so not swallowing it while debugging
 		log.Debug(err)
 
-	} else if m.AddARecord(msg, &state, hostName, addresses) {
+	} else {
+		m.AddARecord(msg, &state, hostName, addresses)
 		log.Debug(msg)
-		w.WriteMsg(msg)
-		return dns.RcodeSuccess, nil
 	}
 
 	// Plugin only processes A and AAAA type multicast queries (.local or single name)
-	// Do not forward those to external resolvers. If we don't have an answer no one does
-	log.Debugf("No records found for '%s', returning NXDOMAIN.", state.QName())
-	return dns.RcodeNameError, nil
+	// Whether an answer was found or not this is end of the line, do not forward to external resolvers
+	// Always return NOERROR since we are not authoritative for this domain
+	w.WriteMsg(msg)
+	return dns.RcodeSuccess, nil
 }
 
 func GetPrimaryInterface(ctx context.Context, resolver *resolve1.Manager) int32 {

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -11,6 +11,9 @@
     template ANY AAAA local.hass.io hassio {
         rcode NOERROR
     }
+    template ANY A local.hass.io hassio {
+        rcode NXDOMAIN
+    }
     mdns
     forward . {{ join " " .servers }} {{ if len .locals | eq 0 }}dns://127.0.0.11{{ else }}{{ join " " .locals }}{{ end }} {
         except local.hass.io


### PR DESCRIPTION
Fixes #85 by responding with an NXDOMAIN if a `local.hass.io` name is not found in our hosts file. We are authoritative on that domain in networks with supervisor and so there's no reason to keep looking if we can't find it.

Additionally fixes #70. When reviewing the SERVFAILS that occurred when an LLMNR name was looked up (single name, no TLD) I realized that generally only bad things happen if we continue looking up multicast names past the MDNS plug-in. Since the MDNS plug-in asks the host for an answer it will get an answer for any multicast names as long as the host has one. And if the host doesn't its unlikely any of the other potential forwarding servers will either. But trying will likely leak private host names to external resolvers.

There is a risk with this. It is possible to add a dns rewrite entry for something like `my-server.local` in some DNS servers instead of properly using MDNS. This will no longer resolve after this change for users doing this because `systemd-resolved` also [refuses to forward multicast names to other resolvers](https://github.com/systemd/systemd/blob/2afb2f4a9d6a497dfbe1983fbe1bac297a8dc52b/src/resolve/resolved-dns-scope.c#L797-L813). But given what we are doing has caused a CVE and I think we should follow `systemd-resolved` example and stop at the MDNS plugin as well.

Note that if we cannot reach `systemd-resolved` (can occur only on an unsupported system) then the MDNS plugin continues to pass the request along as normal. It can't answer any queries in this situation so that is the best it can do.