### PR TITLE
Skip fallback DNS when it is disabled

### DIFF
--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -21,7 +21,7 @@
         health_check 1m
         max_fails 5
     }
-    fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553
+    {{ if .fallback }}fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553{{ end }}
     cache 600
 }
 


### PR DESCRIPTION
Only include fallback DNS in the corefile when option is enabled.
Supervisor parent PR https://github.com/home-assistant/supervisor/pull/3586