### PR TITLE
Don't try to handle health-check messages in fallback chain

### DIFF
--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -22,6 +22,10 @@
 .:5553 {
     log
     errors
+    # The fallback server should not process health-check messages.
+    template IN NS . {
+        rcode REFUSED
+    }
     forward . tls://1.1.1.1 tls://1.0.0.1 {
         tls_servername cloudflare-dns.com
         except local.hass.io

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -31,6 +31,10 @@
     }{{ end }}
     errors
     {{ if .debug }}debug{{ end }}
+    # The fallback server should not process health-check messages.
+    template IN NS . {
+        rcode REFUSED
+    }
     forward . tls://1.1.1.1 tls://1.0.0.1 {
         tls_servername cloudflare-dns.com
         max_fails 0


### PR DESCRIPTION
This is intended to handle the worst part of #90 (continuously sending requests to cloudflare DNS when blocked) by making the DNS spam no longer be continuous, and only happen in shorter bursts when the local servers return NXDomain. See the commit message text below (after the horizontal rule).

I'm not actually sure what the best way to test this change out locally is. There seems to be an absence of documentation around testing changes to supervisor plugins.  

-----

If the fallback chain takes more than 2 seconds to resolve a query the fallback plugin's internal forward plugin will think it has failed and begin sending health checks every 0.5 seconds.

By immediately returning any reply for the health-check message (even an error), it will be deemed a healthy upstream server, and health-checks will stop.

If Cloudflare is inaccessible then it is very easy for it to take more than 2 seconds to process a request, and piling on a bunch of health-check messages makes things much much worse.

Refusing this specific request should have no ill effect, as there is not normally any need to make an `IN NS .` request, especially of an stub or recursive resolver, and in any event, normally the main chain would handle this.