### PR TITLE
Avoid repeated Cloudlflare resolve attempts when DNS over TLS is blocked

### DIFF
--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -10,22 +10,34 @@
     template ANY AAAA local.hass.io hassio {
         rcode NOERROR
     }
+    template ANY A local.hass.io hassio {
+        rcode NXDOMAIN
+    }
     mdns
-    forward . dns://172.0.0.11:53 dns://127.0.0.1:5553 {
+    forward . dns://127.0.0.11 {
         except local.hass.io
         policy sequential
         health_check 1m
+        max_fails 5
     }
+    fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553
     cache
 }
 
 .:5553 {
     log
     errors
+    template IN NS . {
+        rcode REFUSED
+    }
+    template IN HINFO . {
+        rcode REFUSED
+    }
     forward . tls://1.1.1.1 tls://1.0.0.1 {
         tls_servername cloudflare-dns.com
+        max_fails 2
         except local.hass.io
-        health_check 5m
+        health_check 10m
     }
-    cache
+    cache 600
 }

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -30,11 +30,18 @@
         class error
     }{{ end }}
     errors
+    template IN NS . {
+        rcode REFUSED
+    }
+    template IN HINFO . {
+        rcode REFUSED
+    }
     {{ if .debug }}debug{{ end }}
     forward . tls://1.1.1.1 tls://1.0.0.1 {
         tls_servername cloudflare-dns.com
-        max_fails 0
+        max_fails 2
         except local.hass.io
+        health_check 10m
     }
     cache 600
 }


### PR DESCRIPTION
When a first resolve attempt on the fallback chain (:5553) fails, the fallback plug-in of the main chain will trigger health check. By default health checks sends a request every 0.5s as long as upstream reports unhealthy (default value). Unfortuntely the fallback plug-in's health check can't be confiugred currently.

Each of these health checks will trigger a 5s resolve attempt by the fallback chains forward plug-in. And since we get a health check every 0.5s, and health checks on the fallback chain are disabled, this leads to non-stop resolve attempts, forever.

On-top of that, even when the primary/DHCP provided DNS server is working, the loop plug-in will trigger a first resolve attempt on the fallback chain still! This means, even with a working primary DNS sever, the fallback chain will enter a runaway loop still!

This change does several things:
- Handle the loop check using a template plug-in. This avoids a loop test requests to Cloudflare. With that, and a working primary DNS server, no DNS requests will get sent to Cloudflare by default.
- Handle the health check of the fallback plug-in using a template plug-in. This essentially "disables" health check on the primary chains fallback plug-in (which would be the better approach, if that were possible).
- Reenable health checks in the fallback chain, to avoid repeated attempts to Cloudflare when it's not available.

Fixes #90