### PR TITLE
Bump CoreDNS to 1.11.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM
 
-FROM --platform=amd64 golang:1.23.2-alpine3.20 AS builder
+FROM --platform=amd64 golang:1.23.3-alpine3.20 AS builder
 
 WORKDIR /usr/src
 ARG BUILD_ARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILD_FROM
 
-FROM --platform=amd64 golang:1.22-alpine3.19 AS builder
+FROM --platform=amd64 golang:1.23.2-alpine3.20 AS builder
 
 WORKDIR /usr/src
 ARG BUILD_ARCH

--- a/build.yaml
+++ b/build.yaml
@@ -1,10 +1,10 @@
 image: ghcr.io/home-assistant/{arch}-hassio-dns
 build_from:
-  aarch64: ghcr.io/home-assistant/aarch64-base:3.19
-  armhf: ghcr.io/home-assistant/armhf-base:3.19
-  armv7: ghcr.io/home-assistant/armv7-base:3.19
-  amd64: ghcr.io/home-assistant/amd64-base:3.19
-  i386: ghcr.io/home-assistant/i386-base:3.19
+  aarch64: ghcr.io/home-assistant/aarch64-base:3.20
+  armhf: ghcr.io/home-assistant/armhf-base:3.20
+  armv7: ghcr.io/home-assistant/armv7-base:3.20
+  amd64: ghcr.io/home-assistant/amd64-base:3.20
+  i386: ghcr.io/home-assistant/i386-base:3.20
 codenotary:
   signer: notary@home-assistant.io
   base_image: notary@home-assistant.io
@@ -21,4 +21,4 @@ labels:
   org.opencontainers.image.documentation: https://www.home-assistant.io/docs/
   org.opencontainers.image.licenses: Apache License 2.0
 args:
-  COREDNS_VERSION: 1.8.7
+  COREDNS_VERSION: 1.11.3

--- a/build.yaml
+++ b/build.yaml
@@ -21,4 +21,4 @@ labels:
   org.opencontainers.image.documentation: https://www.home-assistant.io/docs/
   org.opencontainers.image.licenses: Apache License 2.0
 args:
-  COREDNS_VERSION: 1.11.3
+  COREDNS_VERSION: 1.11.4

--- a/plugins/fallback/forward.go
+++ b/plugins/fallback/forward.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin/forward"
 	"github.com/coredns/coredns/plugin/pkg/parse"
+	"github.com/coredns/coredns/plugin/pkg/proxy"
 	"github.com/coredns/coredns/plugin/pkg/transport"
 )
 
@@ -40,7 +41,7 @@ func initForward(c *caddy.Controller) (*forward.Forward, error) {
 		if trans != transport.DNS {
 			return f, fmt.Errorf("only dns transport allowed")
 		}
-		p := forward.NewProxy(h, trans)
+		p := proxy.NewProxy("Fallback", h, trans)
 		p.SetExpire(defaultExpire)
 		f.SetProxy(p)
 	}


### PR DESCRIPTION
There have been several security fixes since v1.8.7 which was released in January 2022. For example, CVE-2022-27191 and CVE-2022-28948 were mentioned in version v1.9.3 and security issues discovered in an audit were fixed in v1.9.2. There were also plenty of bugfixes done in the last 2.5 years.