### PR TITLE
Use CoreDNS default cache settings

### DIFF
--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -39,5 +39,5 @@
         except local.hass.io
         health_check 10m
     }
-    cache 600
+    cache
 }

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -22,7 +22,7 @@
         max_fails 5
     }
     {{ if .fallback }}fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553{{ end }}
-    cache 600
+    cache
 }
 
 .:5553 {
@@ -43,5 +43,5 @@
         except local.hass.io
         health_check 10m
     }
-    cache 600
+    cache
 }


### PR DESCRIPTION
Currently our cache settings limit the maximum time a DNS record can be cached to 600 seconds. However, from code history it is unclear why cache is set to that as maximum.

A DNS entry which changes often has a lower TTL in it's response, which will be still accepted. So using the default cache setting only affects records which do have a higher TTL on their end already (and thuse likely anyways cached in the usptream DNS).

Relates to #147