### PR TITLE
Reload hosts file every 250ms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG COREDNS_VERSION="1.11.4"
 
 # Build CoreDNS
 COPY plugins plugins
+COPY patches patches
 RUN \
     set -x \
     && apk add --no-cache \
@@ -15,6 +16,7 @@ RUN \
     && git clone --depth 1 -b v${COREDNS_VERSION} https://github.com/coredns/coredns \
     && cp -rf plugins/* coredns/plugin/ \
     && cd coredns \
+    && git apply --verbose ../patches/*.patch \
     && sed -i "/^template:template/d" plugin.cfg \
     && sed -i "/^hosts:.*/a template:template" plugin.cfg \
     && sed -i "/^forward:.*/i fallback:fallback" plugin.cfg \

--- a/patches/0001-plugin-hosts-only-open-hosts-file-when-it-changed.patch
+++ b/patches/0001-plugin-hosts-only-open-hosts-file-when-it-changed.patch
@@ -1,0 +1,53 @@
+plugin/hosts: only open hosts file when it changed
+
+readHosts() opens and closes the hosts file on every reload tick just
+to read its metadata. Stat the path first and open the file only when
+mtime/size actually changed, so the steady-state cost of a short
+reload interval is a single stat call without fd churn.
+
+Backport of upstream https://github.com/coredns/coredns/pull/8407
+rebased onto CoreDNS v1.11.4.
+
+diff --git a/plugin/hosts/hostsfile.go b/plugin/hosts/hostsfile.go
+index 04747ef8..6270e7f1 100644
+--- a/plugin/hosts/hostsfile.go
++++ b/plugin/hosts/hostsfile.go
+@@ -109,22 +109,31 @@ type Hostsfile struct {
+ 
+ // readHosts determines if the cached data needs to be updated based on the size and modification time of the hostsfile.
+ func (h *Hostsfile) readHosts() {
+-	file, err := os.Open(h.path)
++	// Only stat the file to check for changes; the file is opened for parsing
++	// only when it actually changed.
++	pstat, err := os.Stat(h.path)
+ 	if err != nil {
+ 		// We already log a warning if the file doesn't exist or can't be opened on setup. No need to return the error here.
+ 		return
+ 	}
+-	defer file.Close()
++	h.RLock()
++	size := h.size
++	h.RUnlock()
+ 
+-	stat, err := file.Stat()
++	if h.mtime.Equal(pstat.ModTime()) && size == pstat.Size() {
++		return
++	}
++
++	file, err := os.Open(h.path)
+ 	if err != nil {
+ 		return
+ 	}
+-	h.RLock()
+-	size := h.size
+-	h.RUnlock()
++	defer file.Close()
+ 
+-	if h.mtime.Equal(stat.ModTime()) && size == stat.Size() {
++	// Stat the opened file so the recorded mtime/size always match the content
++	// that was parsed, even if the file is replaced between the stat and open.
++	stat, err := file.Stat()
++	if err != nil {
+ 		return
+ 	}
+ 

--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -5,6 +5,7 @@
     errors
     loop
     hosts /config/hosts {
+        reload 250ms
         fallthrough
     }
     template ANY AAAA local.hass.io hassio {

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -6,6 +6,7 @@
     loop
     {{ if .debug }}debug{{ end }}
     hosts /config/hosts {
+        reload 250ms
         fallthrough
     }
     template ANY AAAA local.hass.io hassio {


### PR DESCRIPTION
## Proposed change

Set `reload 250ms` on the CoreDNS `hosts` plugin (default: 5s).

Supervisor writes new add-on entries to `/config/hosts` immediately when a container starts, but CoreDNS only re-reads the file every 5s. Queries for the new name within that window fall through to the `local.hass.io` template and get an authoritative NXDOMAIN. This breaks discovery-triggered connections — observed with Home Assistant Core failing to reach the OpenThread Border Router add-on right after startup, where the hosts entry landed ~0.7s before Core's first query.

The periodic reload check is a single `stat()` against an in-cache inode; the file is only re-parsed when mtime/size actually changed. So the steady-state cost of a 250ms interval is negligible (no disk I/O), while the stale window shrinks from 5s to 250ms.

Companion PR: disabling negative caching for `local.hass.io`, so a query that still lands in the remaining window costs one failed lookup instead of a ~5s poisoned cache entry.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)