### PR TITLE
Disable negative caching for local.hass.io

### DIFF
--- a/rootfs/etc/corefile
+++ b/rootfs/etc/corefile
@@ -21,7 +21,9 @@
         max_fails 5
     }
     fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553
-    cache
+    cache {
+        disable denial local.hass.io
+    }
 }
 
 .:5553 {

--- a/rootfs/usr/share/tempio/corefile
+++ b/rootfs/usr/share/tempio/corefile
@@ -22,7 +22,9 @@
         max_fails 5
     }
     {{ if .fallback }}fallback REFUSED,SERVFAIL,NXDOMAIN . dns://127.0.0.1:5553{{ end }}
-    cache
+    cache {
+        disable denial local.hass.io
+    }
 }
 
 .:5553 {


### PR DESCRIPTION
## Proposed change

Add `disable denial local.hass.io` to the `cache` plugin on the main server block.

When a name under `local.hass.io` is queried before Supervisor's freshly written hosts entry has been picked up (e.g. right after an add-on started), the resulting NXDOMAIN is negative-cached for ~5s — so resolution keeps failing even after the hosts file reload has made the entry visible.

These names are answered from the local hosts file (or the `template` fallback), so negative caching provides no upstream offload; disabling it only removes the failure amplification. Positive answers are still cached.

Companion PR: #201 (faster hosts file reload), which shrinks the window in which the stale NXDOMAIN can be produced in the first place.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)