### PR TITLE
Skip s6 SIGTERM-to-SIGKILL grace time at container stop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ RUN \
 # Base image updated by Renovate, update versionCompatibility on Alpine base bump
 FROM ghcr.io/home-assistant/base:3.24-2026.06.1@sha256:94ff231402a5e7ad2a82e261ad5fa4ffae7d7bb095c3febb2edbdf309c9b6aca
 
+# Everything in this image runs s6-supervised and is stopped gracefully
+# by s6-rc: skip the blind SIGTERM-to-SIGKILL grace sleep at shutdown.
+ENV S6_KILL_GRACETIME=0
+
 WORKDIR /config
 COPY --from=builder /usr/src/coredns/coredns /usr/bin/coredns
 COPY rootfs /


### PR DESCRIPTION
## Description

At container shutdown, after s6-rc has stopped all services gracefully, `s6-linux-init-shutdownd` broadcasts SIGTERM, sleeps a fixed `S6_KILL_GRACETIME` (default 3000 ms), and broadcasts SIGKILL. The sleep is unconditional ([upstream source](https://github.com/skarnet/s6-linux-init/blob/master/src/shutdown/s6-linux-init-shutdownd.c)):

```c
kill(-1, SIGTERM) ;
kill(-1, SIGCONT) ;
tain_from_millisecs(&deadline, grace_time) ;
...
deepsleepuntil_g(&deadline) ;
kill(-1, SIGKILL) ;
```

It is a grace window for processes running *outside* s6 supervision — s6 has no way to check whether any exist. Everything in this image runs as a supervised s6 service (CoreDNS via `services.d`), so every stop of `hassio_dns` idles for a flat 3 seconds after CoreDNS is already down.

During a Home Assistant OS shutdown the Supervisor stops its plugin containers sequentially, so these windows add up to ~15 s of dead time per reboot. Measured on a generic-x86-64 install (visible thanks to home-assistant/operating-system#4923): `hassio_dns` takes 3.04 s to stop, of which CoreDNS's actual stop is ~30 ms.

Measurement against the current base image (3.24, s6-overlay 3.2.2.0): `docker stop` 3.18 s → 0.18 s.

**Reviewer caveat:** this is only safe for images where everything runs under s6 supervision. A container CMD is *not* stopped by s6-rc — on `docker stop`, a CMD's only graceful-exit window is exactly this grace time. This image has no CMD.

**Alternative:** with grace time 0, a process that ever escaped supervision would be SIGKILLed with no grace and no trace (neither s6 nor Docker nor the kernel logs it). #204 adds a `cont-finish.d` tripwire that detects and logs exactly that; this PR is the minimal variant. Pick one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)