### PR TITLE
Skip s6 SIGTERM-to-SIGKILL grace time at container stop (with stray-process tripwire)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ RUN \
 # Base image updated by Renovate, update versionCompatibility on Alpine base bump
 FROM ghcr.io/home-assistant/base:3.24-2026.06.1@sha256:94ff231402a5e7ad2a82e261ad5fa4ffae7d7bb095c3febb2edbdf309c9b6aca
 
+# Everything in this image runs s6-supervised: skip the blind
+# SIGTERM-to-SIGKILL grace sleep at shutdown (guarded by
+# /etc/cont-finish.d/stray-check.sh).
+ENV S6_KILL_GRACETIME=0
+
 WORKDIR /config
 COPY --from=builder /usr/src/coredns/coredns /usr/bin/coredns
 COPY rootfs /

--- a/rootfs/etc/cont-finish.d/stray-check.sh
+++ b/rootfs/etc/cont-finish.d/stray-check.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# ==============================================================================
+# Detect processes that escaped s6 supervision
+# All s6-rc services have already been stopped gracefully at this point, so
+# any process outside the s6 supervision tree was leaked by a service or
+# init script. It is about to be SIGKILLed without any grace period
+# (S6_KILL_GRACETIME=0): fix it by supervising the process, not by
+# re-adding grace time.
+# Plain sh with only builtins: bashio startup alone costs ~0.8s, which is
+# most of the time this image saves by skipping the grace sleep.
+# ==============================================================================
+
+# A process is part of shutdown machinery if its ancestry (self included)
+# reaches this script or an s6 process before reaching PID 1.
+is_machinery() {
+    local pid comm stat
+    pid=$1
+    while [ "${pid}" -gt 1 ] 2>/dev/null; do
+        [ "${pid}" = "$$" ] && return 0
+        IFS= read -r comm < "/proc/${pid}/comm" 2>/dev/null || return 0
+        case "${comm}" in s6-*) return 0 ;; esac
+        IFS= read -r stat < "/proc/${pid}/stat" 2>/dev/null || return 0
+        set -- ${stat##*) }
+        pid=$2
+    done
+    return 1
+}
+
+for proc in /proc/[0-9]*; do
+    pid=${proc#/proc/}
+    [ "${pid}" -eq 1 ] && continue
+
+    IFS= read -r stat < "${proc}/stat" 2>/dev/null || continue
+    # fields after the comm: $1 state, $2 ppid; skip zombies awaiting reaping
+    set -- ${stat##*) }
+    state=$1
+    ppid=$2
+    [ "${state}" = "Z" ] && continue
+
+    is_machinery "${pid}" && continue
+
+    IFS= read -r comm < "${proc}/comm" 2>/dev/null || continue
+    echo "stray-check: WARNING: stray process at shutdown:" \
+        "PID ${pid} (${comm}, parent ${ppid}) escaped s6 supervision" \
+        "and is killed without grace period" >&2
+done
+
+exit 0


### PR DESCRIPTION
## Description

At container shutdown, after s6-rc has stopped all services gracefully, `s6-linux-init-shutdownd` broadcasts SIGTERM, sleeps a fixed `S6_KILL_GRACETIME` (default 3000 ms), and broadcasts SIGKILL. The sleep is unconditional ([upstream source](https://github.com/skarnet/s6-linux-init/blob/master/src/shutdown/s6-linux-init-shutdownd.c)):

```c
kill(-1, SIGTERM) ;
kill(-1, SIGCONT) ;
tain_from_millisecs(&deadline, grace_time) ;
...
deepsleepuntil_g(&deadline) ;
kill(-1, SIGKILL) ;
```

It is a grace window for processes running *outside* s6 supervision — s6 has no way to check whether any exist. Everything in this image runs as a supervised s6 service (CoreDNS via `services.d`), so every stop of `hassio_dns` idles for a flat 3 seconds after CoreDNS is already down.

During a Home Assistant OS shutdown the Supervisor stops its plugin containers sequentially, so these windows add up to ~15 s of dead time per reboot. Measured on a generic-x86-64 install (visible thanks to home-assistant/operating-system#4923): `hassio_dns` takes 3.04 s to stop, of which CoreDNS's actual stop is ~30 ms.

This variant pairs `S6_KILL_GRACETIME=0` with a **shutdown tripwire**: with grace time 0, a process that ever escaped supervision would be SIGKILLed with no grace and *no trace* — neither s6 nor Docker nor the kernel logs it. The `cont-finish.d` script runs after all services are down and right before the kill broadcast, and warns about any process found outside the s6 supervision tree. If it ever fires, the fix is to supervise that process, not to re-add grace time.

Verified against the current base image (3.24, s6-overlay 3.2.2.0):
- `docker stop`: 3.18 s → ~0.5 s (the tripwire itself costs ~0.3 s; it is plain sh builtins because bashio startup alone is ~0.8 s)
- clean shutdown: no output
- planted strays (`docker exec -d sleep …`): each reported with PID, comm and parent

**Reviewer caveat:** this is only safe for images where everything runs under s6 supervision. A container CMD is *not* stopped by s6-rc — on `docker stop`, a CMD's only graceful-exit window is exactly this grace time. This image has no CMD.

**Alternative:** #203 is the same change without the tripwire. Pick one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
