### PR TITLE
Bump Go builder to 1.26.5 on Alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine3.23 AS builder
+FROM golang:1.26.5-alpine3.24 AS builder
 
 WORKDIR /usr/src
 ARG TARGETARCH


### PR DESCRIPTION
## Proposed change

Bump the Go builder image from `1.25.7-alpine3.23` to `1.26.5-alpine3.24` — the latest Go 1.26 patch, on Alpine 3.24 to match the runtime base image bumped in #198.

CoreDNS 1.11.4 declares `go 1.22.0` in its go.mod and its quic-go dependency (v0.48.1) has no maximum Go version constraint, so it is compatible with the Go 1.26 toolchain.

Verified with a local build of the builder stage including the custom plugins (fallback, mdns, template): the resulting binary reports `CoreDNS-1.11.4, linux/amd64, go1.26.5`.

## Type of change

- Dependency upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)